### PR TITLE
Box width css rules

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@
     <!-- Trix Editor -->
     <div id="editor">
       <form>
-        <input id="notepad" value="" type="hidden" name="content" />
-        <trix-editor input="notepad"></trix-editor>
+        <input id="input-pad" value="" type="hidden" name="content" />
+        <trix-editor id="notepad" input="input-pad"></trix-editor>
       </form>
     </div>
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -16,10 +16,12 @@ h4 {
 }
 
 #editor {
-  width: 50%;
   margin: 25px;
+  max-width: 80%;
 }
 
 #notepad {
-  margin: 25px;
+  box-shadow: 5px 5px darkslategrey;
+  width: auto;
+  min-width: available;
 }


### PR DESCRIPTION
Since the `input` field is actually `hidden` no css is applied to it.
Now you can apply any css to `#notepad` in your `styles.css`
https://github.com/basecamp/trix#styling-formatted-content